### PR TITLE
Fix custom host port retrieval

### DIFF
--- a/macLlama/Services/NetworkService/OllamaNetworkService.swift
+++ b/macLlama/Services/NetworkService/OllamaNetworkService.swift
@@ -18,8 +18,8 @@ actor OllamaNetworkService {
     static var apiHostAddress: String {
         let hostProtocol = UserDefaults.standard.string(forKey: "hostProtocol") ?? "http://"
         let hostAddress = UserDefaults.standard.string(forKey: "hostAddress") ?? "127.0.0.1"
-        let hostPort = UserDefaults.standard.string(forKey: "hostPort") ?? "11434"
-        let fullAddress = "\(hostProtocol)\(hostAddress):\(hostPort)"
+        let hostPortInt = UserDefaults.standard.object(forKey: "hostPort") as? Int ?? 11434
+        let fullAddress = "\(hostProtocol)\(hostAddress):\(hostPortInt)"
         
         #if DEBUG
         debugPrint("Called API: \(fullAddress)")


### PR DESCRIPTION
## Summary
- read `hostPort` from `UserDefaults` as an `Int`

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_6852a44c1d44832e8c473ac6d954fb37